### PR TITLE
fixed OverflowException when running as x64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Including Vestris.ResourceLib.pdb and Vestris.ResourceLib.xml in release zip for documentation and easier debugging support - [@icnocop](https://github.com/icnocop).
 * [CI](https://ci.appveyor.com/project/dblock/resourcelib): Setup CI on AppVeyor - [@dblock](https://github.com/dblock).
 * [#26](https://github.com/dblock/resourcelib/pull/26): Fixed opening PE files at non-ANSI paths by changing from ANSI to Wide version of PInvoke - [@hypersw](https://github.com/hypersw).
+* [#31](https://github.com/dblock/resourcelib/pull/31): Fixed OverflowException when running as x64 - [@thoemmi](https://github.com/thoemmi).
 
 ### 1.4 (3/3/2013)
 

--- a/Source/ResourceLib/FontDirectoryResource.cs
+++ b/Source/ResourceLib/FontDirectoryResource.cs
@@ -78,7 +78,7 @@ namespace Vestris.ResourceLib
                 _fonts.Add(fontEntry);
             }
 
-            int reservedLen = _size - (lpRes.ToInt32() - lpHead.ToInt32() - 1);
+            int reservedLen = _size - (int)(lpRes.ToInt64() - lpHead.ToInt64() - 1);
             _reserved = new byte[reservedLen];
             Marshal.Copy(lpRes, _reserved, 0, reservedLen);
 

--- a/Source/ResourceLib/ResourceId.cs
+++ b/Source/ResourceLib/ResourceId.cs
@@ -113,7 +113,7 @@ namespace Vestris.ResourceLib
         /// <param name="value">Resource pointer.</param>
         internal static bool IsIntResource(IntPtr value)
         {
-            return (uint) value <= UInt16.MaxValue;
+            return value.ToInt64() <= UInt16.MaxValue;
         }
 
         /// <summary>

--- a/Source/ResourceLibUnitTests/ResourceLibUnitTests.csproj
+++ b/Source/ResourceLibUnitTests/ResourceLibUnitTests.csproj
@@ -15,7 +15,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -34,6 +34,7 @@
     <MSBuildCommunityTasksPath>$(SolutionDir)\Build</MSBuildCommunityTasksPath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,6 +45,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -53,6 +55,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework">


### PR DESCRIPTION
When running as x64, `ResourceId.IsIntResource` threw an `OverflowException`. (64 bit pointers can't be cast to `uint`)