### PR TITLE
creation of NuGet package

### DIFF
--- a/ResourceLib.nuspec
+++ b/ResourceLib.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Vestris.ResourceLib</id>
+    <version>$version$</version>
+    <title>Vestris Resource Lib</title>
+    <authors>dblock</authors>
+    <owners>dblock</owners>
+    <licenseUrl>https://github.com/dblock/resourcelib/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/dblock/resourcelib</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>C# File Resource Management Library</description>
+    <copyright>Copyright 2016</copyright>
+    <tags>Resource Win32</tags>
+  </metadata>
+  <files>
+    <file src="Source\ResourceLib\bin\$configuration$\Vestris.ResourceLib.dll" target="lib\" />
+    <file src="Source\ResourceLib\bin\$configuration$\Vestris.ResourceLib.xml" target="lib\" />
+  </files>
+</package>

--- a/ResourceLib.proj
+++ b/ResourceLib.proj
@@ -31,6 +31,7 @@
   <CallTarget Targets="code" />
   <CallTarget Targets="run_test_only" />
   <CallTarget Targets="zip" />
+  <CallTarget Targets="package" />
   <CallTarget Targets="built" />
  </Target>
  <Target Name="code_and_test" DependsOnTargets="configurations">
@@ -90,6 +91,9 @@
   <Zip ZipFileName="target\$(Configuration)\Vestris.ResourceLib.$(Major).$(Minor).zip" WorkingDirectory="target\$(Configuration)"
        Condition="'$(Configuration)'=='Release'" Files="@(PackageFiles)" />
  </Target>
+  <Target Name="package" DependsOnTargets="version;configurations">
+    <Exec Command=".nuget\nuget.exe pack ResourceLib.nuspec -version $(Major).$(Minor).$(Build).$(Revision) -Properties Configuration=$(Configuration) -OutputDirectory target\$(Configuration)" />
+  </Target>
  <Target Name="built" DependsOnTargets="version">
   <Message Text="Built version: $(Major).$(Minor).$(Build).$(Revision)"/>
  </Target>


### PR DESCRIPTION
With this PR, calling `build.bat all` will also create a NuGet package in the `target\$(configuration)` folder.

If you want to automate the upload to the NuGet gallery, you can [instruct AppVeyor to do so](https://www.appveyor.com/docs/deployment/nuget).

This also fixes #13.