### PR TITLE
Release version 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
-### Next Release
+### 1.5 (3/28/2016)
+
+**Misc**
 
 * [#9](https://github.com/dblock/resourcelib/pull/9): Added a strong signature to the .NET assembly - [@dwmkerr](https://github.com/dwmkerr).
-* [#10](https://github.com/dblock/resourcelib/issues/10): Fixed System.OverflowException: Arithmetic operation resulted in an overflow (64-bit systems) by replacing most calls to ToInt32 with ToInt64 - [@icnocop](https://github.com/icnocop).
-* [#16](https://github.com/dblock/resourcelib/issues/16): Fixed NuGet error "Package restore is disabled by default." when building by updating to NuGet 2.8.1 - [@icnocop](https://github.com/icnocop).
 * Including Vestris.ResourceLib.pdb and Vestris.ResourceLib.xml in release zip for documentation and easier debugging support - [@icnocop](https://github.com/icnocop).
 * [CI](https://ci.appveyor.com/project/dblock/resourcelib): Setup CI on AppVeyor - [@dblock](https://github.com/dblock).
+* [#32](https://github.com/dblock/resourcelib/pull/32): Creation of NuGet package - [@thoemmi](https://github.com/thoemmi).
+
+**Bugs**
+
+* [#10](https://github.com/dblock/resourcelib/issues/10): Fixed System.OverflowException: Arithmetic operation resulted in an overflow (64-bit systems) by replacing most calls to `ToInt32` with `ToInt64` - [@icnocop](https://github.com/icnocop).
+* [#16](https://github.com/dblock/resourcelib/issues/16): Fixed NuGet error "Package restore is disabled by default." when building by updating to NuGet 2.8.1 - [@icnocop](https://github.com/icnocop).
 * [#26](https://github.com/dblock/resourcelib/pull/26): Fixed opening PE files at non-ANSI paths by changing from ANSI to Wide version of PInvoke - [@hypersw](https://github.com/hypersw).
 * [#31](https://github.com/dblock/resourcelib/pull/31): Fixed OverflowException when running as x64 - [@thoemmi](https://github.com/thoemmi).
 

--- a/ResourceLib.proj
+++ b/ResourceLib.proj
@@ -22,7 +22,7 @@
   <Copyright>Copyright (c) Vestris Inc.</Copyright>
   <Trademark>All Rights Reserved</Trademark>
   <MajorVersion>1</MajorVersion>
-  <MinorVersion>4</MinorVersion>
+  <MinorVersion>5</MinorVersion>
   <RevisionVersion>0</RevisionVersion>
  </PropertyGroup>
  <Target Name="all" DependsOnTargets="configurations">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,3 +4,10 @@ version: 0.{build}
 
 build_script:
   - build all /p:Configuration=Release
+
+artifacts:
+  - path: target\Release\*.zip
+    name: ZIP
+
+  - path: target\Release\*.nupkg
+    name: NuGet package


### PR DESCRIPTION
IMHO ResourceLib is ready for a new release. The last one is more than three years old, and many issues related to x64 have been fixed since then.

This PR prepares the release of v1.5:

- [x] Increased the version in `Resourcelib.Proj`.
- [x] Updated `CHANGELOG.md`.
- [x] Configured the CI build to output the zipped assembly incl. documentation and the NuGet package as artifacts.

If you accept this PR, I'd add the [artifacts from the CI build](https://ci.appveyor.com/project/dblock/resourcelib/branch/master/artifacts) to the [Release page](https://github.com/dblock/resourcelib/releases) and upload the NuGet package to the NuGet Gallery.