### PR TITLE
Batch update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### v.Next
+### 1.6 (not released yet)
 
 **New Features**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v.Next
+
+**New Features**
+
+* [#40](https://github.com/dblock/resourcelib/pull/40): Added `Resource.Save(string filename, IEnumerable<Resource> resources)` for saving multiple resources in one batch - [@thoemmi](https://github.com/thoemmi).
+
 ### 1.5 (3/28/2016)
 
 **Misc**

--- a/Source/ResourceLib/Resource.cs
+++ b/Source/ResourceLib/Resource.cs
@@ -304,6 +304,10 @@ namespace Vestris.ResourceLib
 
             try
             {
+                if (data != null && data.Length == 0)
+                {
+                    data = null;
+                }
                 if (!Kernel32.UpdateResource(h, type.Id, name.Id,
                     lang, data, (data == null ? 0 : (uint)data.Length)))
                 {
@@ -340,7 +344,7 @@ namespace Vestris.ResourceLib
                     var imageResource = resource as IconImageResource;
                     if (imageResource != null)
                     {
-                        var bytes = imageResource.Image.Data;
+                        var bytes = imageResource.Image == null ? null : imageResource.Image.Data;
                         if (!Kernel32.UpdateResource(h, imageResource.Type.Id, new IntPtr(imageResource.Id),
                             imageResource.Language, bytes, (bytes == null ? 0 : (uint)bytes.Length)))
                         {
@@ -350,6 +354,10 @@ namespace Vestris.ResourceLib
                     else
                     {
                         var bytes = resource.WriteAndGetBytes();
+                        if (bytes != null && bytes.Length == 0)
+                        {
+                            bytes = null;
+                        }
                         if (!Kernel32.UpdateResource(h, resource.Type.Id, resource.Name.Id,
                             resource.Language, bytes, (bytes == null ? 0 : (uint)bytes.Length)))
                         {

--- a/Source/ResourceLib/Resource.cs
+++ b/Source/ResourceLib/Resource.cs
@@ -319,5 +319,53 @@ namespace Vestris.ResourceLib
             if (!Kernel32.EndUpdateResource(h, false))
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
+
+
+        /// <summary>
+        /// Save a batch of resources to a given file.
+        /// </summary>
+        /// <param name="filename">Path to an executable file.</param>
+        /// <param name="resources">The resources to write.</param>
+        public static void Save(string filename, IEnumerable<Resource> resources)
+        {
+            IntPtr h = Kernel32.BeginUpdateResource(filename, false);
+
+            if (h == IntPtr.Zero)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            try
+            {
+                foreach (var resource in resources)
+                {
+                    var imageResource = resource as IconImageResource;
+                    if (imageResource != null)
+                    {
+                        var bytes = imageResource.Image.Data;
+                        if (!Kernel32.UpdateResource(h, imageResource.Type.Id, new IntPtr(imageResource.Id),
+                            imageResource.Language, bytes, (bytes == null ? 0 : (uint)bytes.Length)))
+                        {
+                            throw new Win32Exception(Marshal.GetLastWin32Error());
+                        }
+                    }
+                    else
+                    {
+                        var bytes = resource.WriteAndGetBytes();
+                        if (!Kernel32.UpdateResource(h, resource.Type.Id, resource.Name.Id,
+                            resource.Language, bytes, (bytes == null ? 0 : (uint)bytes.Length)))
+                        {
+                            throw new Win32Exception(Marshal.GetLastWin32Error());
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                Kernel32.EndUpdateResource(h, true);
+                throw;
+            }
+
+            if (!Kernel32.EndUpdateResource(h, false))
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
     }
 }

--- a/Source/ResourceLib/Resource.cs
+++ b/Source/ResourceLib/Resource.cs
@@ -302,10 +302,18 @@ namespace Vestris.ResourceLib
             if (h == IntPtr.Zero)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
-            if (!Kernel32.UpdateResource(h, type.Id, name.Id,
-                lang, data, (data == null ? 0 : (uint)data.Length)))
+            try
             {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+                if (!Kernel32.UpdateResource(h, type.Id, name.Id,
+                    lang, data, (data == null ? 0 : (uint)data.Length)))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+            }
+            catch
+            {
+                Kernel32.EndUpdateResource(h, true);
+                throw;
             }
 
             if (!Kernel32.EndUpdateResource(h, false))

--- a/Source/ResourceLib/ResourceInfo.cs
+++ b/Source/ResourceLib/ResourceInfo.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Vestris.ResourceLib
 {
@@ -141,11 +140,11 @@ namespace Vestris.ResourceLib
         /// <param name="size">Size of resource.</param>
         /// <returns>A specialized or a generic resource.</returns>
         protected Resource CreateResource(
-            IntPtr hModule, 
-            IntPtr hResourceGlobal, 
-            ResourceId type, 
-            ResourceId name, 
-            UInt16 wIDLanguage, 
+            IntPtr hModule,
+            IntPtr hResourceGlobal,
+            ResourceId type,
+            ResourceId name,
+            UInt16 wIDLanguage,
             int size)
         {
             if (type.IsIntResource())
@@ -174,6 +173,13 @@ namespace Vestris.ResourceLib
                         return new FontResource(hModule, hResourceGlobal, type, name, wIDLanguage, size);
                     case Kernel32.ResourceTypes.RT_ACCELERATOR:
                         return new AcceleratorResource(hModule, hResourceGlobal, type, name, wIDLanguage, size);
+                    case Kernel32.ResourceTypes.RT_ICON:
+                        return new IconResource(hModule, hResourceGlobal, type, name, wIDLanguage, size);
+                    case Kernel32.ResourceTypes.RT_CURSOR:
+                        return new CursorResource(hModule, hResourceGlobal, type, name, wIDLanguage, size);
+                    default:
+                        System.Diagnostics.Debug.WriteLine($"CreateResource: unhandled type {type.ResourceType}, returning GenericResource");
+                        break;
                 }
             }
 
@@ -214,7 +220,7 @@ namespace Vestris.ResourceLib
                     name, type.TypeName, wIDLanguage), ex);
                 throw ex;
             }
-            
+
             return true;
         }
 
@@ -284,7 +290,7 @@ namespace Vestris.ResourceLib
                 while (resourceEnumerator.MoveNext())
                 {
                     yield return resourceEnumerator.Current;
-                }                
+                }
             }
         }
 

--- a/Source/ResourceLib/ResourceInfo.cs
+++ b/Source/ResourceLib/ResourceInfo.cs
@@ -178,7 +178,7 @@ namespace Vestris.ResourceLib
                     case Kernel32.ResourceTypes.RT_CURSOR:
                         return new CursorResource(hModule, hResourceGlobal, type, name, wIDLanguage, size);
                     default:
-                        System.Diagnostics.Debug.WriteLine($"CreateResource: unhandled type {type.ResourceType}, returning GenericResource");
+                        System.Diagnostics.Debug.WriteLine(string.Format("CreateResource: unhandled type {0}, returning GenericResource", type.ResourceType));
                         break;
                 }
             }
@@ -216,8 +216,7 @@ namespace Vestris.ResourceLib
             }
             catch (Exception ex)
             {
-                _innerException = new Exception(string.Format("Error loading resource '{0}' {1} ({2}).",
-                    name, type.TypeName, wIDLanguage), ex);
+                _innerException = new Exception(string.Format("Error loading resource '{0}' {1} ({2}).", name, type.TypeName, wIDLanguage), ex);
                 throw ex;
             }
 

--- a/Source/ResourceLib/ResourceInfo.cs
+++ b/Source/ResourceLib/ResourceInfo.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Vestris.ResourceLib
 {
@@ -140,11 +141,11 @@ namespace Vestris.ResourceLib
         /// <param name="size">Size of resource.</param>
         /// <returns>A specialized or a generic resource.</returns>
         protected Resource CreateResource(
-            IntPtr hModule,
-            IntPtr hResourceGlobal,
-            ResourceId type,
-            ResourceId name,
-            UInt16 wIDLanguage,
+            IntPtr hModule, 
+            IntPtr hResourceGlobal, 
+            ResourceId type, 
+            ResourceId name, 
+            UInt16 wIDLanguage, 
             int size)
         {
             if (type.IsIntResource())
@@ -173,13 +174,6 @@ namespace Vestris.ResourceLib
                         return new FontResource(hModule, hResourceGlobal, type, name, wIDLanguage, size);
                     case Kernel32.ResourceTypes.RT_ACCELERATOR:
                         return new AcceleratorResource(hModule, hResourceGlobal, type, name, wIDLanguage, size);
-                    case Kernel32.ResourceTypes.RT_ICON:
-                        return new IconResource(hModule, hResourceGlobal, type, name, wIDLanguage, size);
-                    case Kernel32.ResourceTypes.RT_CURSOR:
-                        return new CursorResource(hModule, hResourceGlobal, type, name, wIDLanguage, size);
-                    default:
-                        System.Diagnostics.Debug.WriteLine(string.Format("CreateResource: unhandled type {0}, returning GenericResource", type.ResourceType));
-                        break;
                 }
             }
 
@@ -216,10 +210,11 @@ namespace Vestris.ResourceLib
             }
             catch (Exception ex)
             {
-                _innerException = new Exception(string.Format("Error loading resource '{0}' {1} ({2}).", name, type.TypeName, wIDLanguage), ex);
+                _innerException = new Exception(string.Format("Error loading resource '{0}' {1} ({2}).",
+                    name, type.TypeName, wIDLanguage), ex);
                 throw ex;
             }
-
+            
             return true;
         }
 
@@ -289,7 +284,7 @@ namespace Vestris.ResourceLib
                 while (resourceEnumerator.MoveNext())
                 {
                     yield return resourceEnumerator.Current;
-                }
+                }                
             }
         }
 

--- a/Source/ResourceLib/ResourceUtil.cs
+++ b/Source/ResourceLib/ResourceUtil.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Runtime.InteropServices;
 using System.IO;
 
@@ -9,7 +8,7 @@ namespace Vestris.ResourceLib
     /// <summary>
     /// Resource utilities.
     /// </summary>
-    public abstract class ResourceUtil
+    public static class ResourceUtil
     {
         /// <summary>
         /// Align an address to a 4-byte boundary.

--- a/Source/ResourceLibUnitTests/ResourceTests.cs
+++ b/Source/ResourceLibUnitTests/ResourceTests.cs
@@ -5,7 +5,6 @@ using Vestris.ResourceLib;
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using System.Reflection;
 using System.Web;


### PR DESCRIPTION
As requested in #37, this PR introduces the static method `Resource.Save(string filename, IEnumerable<Resource> resources)` for saving multiple resources in one batch.

For whatever reason the implementation of `IconImageResource` defers from other resources, so I had to add a special code path for saving those resources.